### PR TITLE
Minimum changes to get Caseta Pro bridge working

### DIFF
--- a/lutron.go
+++ b/lutron.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	timeout = 5 * time.Second
+	timeout = 40 * time.Second
 )
 
 type request struct {
@@ -78,7 +78,7 @@ func reader(sock *telnet.Conn, d chan string, e chan error) {
 			e <- err
 			return
 		}
-		str = strings.TrimSpace(str)
+		str = strings.TrimSpace(strings.Replace(str, "GNET> ", "", -1))
 		if str != "" {
 			d <- str
 		}
@@ -278,10 +278,12 @@ func (c *Conn) login(t *telnet.Conn) error {
 	}
 
 	// Expect and disable prompt.
-	if err := expect(t, "GNET> \x00"); err != nil {
+	if err := expect(t, "GNET> "); err != nil {
 		return err
 	}
 	if err := sendln(t, "#MONITORING,12,2"); err != nil {
+		// caseta doesn't support this, reporting ~ERROR,6
+		// this would be an ideal place to perform caseta detection
 		return err
 	}
 	t.SetReadDeadline(time.Time{})


### PR DESCRIPTION
Lutron has a midrange system called Caseta Wireless that uses the same Clear Connect RF technology as RadioRA2, but it's dumbed down and sold directly to consumers. It uses the same Pico remotes, but the other system components are not interchangeable. The "Pro" version of the Caseta Bridge supports a subset of the Lutron integration protocol. Exactly what is supported isn't clear, as Lutron hasn't indicated any willingness to share specifications except with their partners. Regardless, simple device control and monitoring is possible.

This PR has the minimum changes required to get the Caseta Pro bridge working. Namely:

1. The Caseta Pro Bridge takes a very long time to present the login prompt after it accepts a TCP connection. (This could be cleaned up further by using a different timeout for the login sequence.)

2. The #MONITORING command is not supported: The GNET> prompt cannot be disabled, and network updates are always sent. Thus, upon startup there are five ~ERROR,6 messages.

Beyond these gotchas, basic functionality seems to work.

I'm willing to accept that you're likely not interested in compatibility with the Caseta system, but if you are, I'd be happy to submit further PR's as I work out more differences. Thanks!